### PR TITLE
Feature/reusing GitHub workflows

### DIFF
--- a/.github/workflows/build-test-workflow.yaml
+++ b/.github/workflows/build-test-workflow.yaml
@@ -1,0 +1,32 @@
+name: Build & Test Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install the dependencies
+      run: sudo ./scripts/install-deps.sh
+      
+    - name: Setup python virtual env
+      run: ./scripts/setup-venv.sh
+      
+    - name: Run CI test script
+      run: ./scripts/ci-test.sh

--- a/.github/workflows/ci-test-pipeline.yaml
+++ b/.github/workflows/ci-test-pipeline.yaml
@@ -3,66 +3,7 @@ name: CI Testing Pipeline
 on:
   push:
     branches: [ "**" ]
-  schedule:
-    - cron: '0 0 * * *'
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-      with:
-        lfs: true
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    
-    - name: Install the dependencies
-      run: sudo ./scripts/install-deps.sh
-      
-    - name: Setup python virtual env
-      run: ./scripts/setup-venv.sh
-      
-    - name: Run CI test script
-      run: ./scripts/ci-test.sh
-
-  docker_deploy:
-    needs: build_and_test
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check out the code
-      uses: actions/checkout@v2
-      with:
-        lfs: true
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Run build script
-      run: |
-        cd docker 
-        chmod +x build.sh
-        ./build.sh ${{ github.sha }}
-
-    env:
-      DOCKER_CLI_EXPERIMENTAL: enabled
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    uses: ./.github/workflows/build-test-workflow.yaml

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -1,0 +1,44 @@
+name: Nightly CI Test Pipeline
+
+on:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build_and_test:
+    uses: ./.github/workflows/build-test-workflow.yaml
+
+  docker_deploy:
+    needs: build_and_test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v2
+      with:
+        lfs: true
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Run build script
+      run: |
+        cd docker 
+        chmod +x build.sh
+        ./build.sh ${{ github.sha }}
+
+    env:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Updating the github workflows to now add a nightly build which is used to build/test and then build and push a docker image. The CI pipeline for pushes will now only run the build/test jobs. To cater for this, the build/test job has been added to a reusable workflow file.