### PR TITLE
github: Updating the nightly-pipeline.yaml to ensure that the tag ass…

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -34,7 +34,7 @@ jobs:
       run: |
         cd docker 
         chmod +x build.sh
-        ./build.sh ${{ github.sha }}
+        ./build.sh nightly
 
     env:
       DOCKER_CLI_EXPERIMENTAL: enabled


### PR DESCRIPTION
…igned to the docker image is "nightly" and not the commit SHA.