### PR TITLE
Fix broken install-deps.sh script

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -8,3 +8,5 @@ apt-get install -y \
   libasound2-dev \
   python3-dev \
   python3-pip
+
+pip install virtualenv


### PR DESCRIPTION
Updating the `install-deps.sh` script so that it installs `virtualenv` via `pip`, as this was not happening meaning this script would break on a fresh install of Ubuntu.